### PR TITLE
Added cpu-keepalive methods

### DIFF
--- a/include/mce/dbus-names.h
+++ b/include/mce/dbus-names.h
@@ -344,7 +344,7 @@
  * lost D-Bus connection (exit, crash, ...) or all timeouts
  * have been missed.
  *
- * @since v1.12.7
+ * @since v1.12.8
  *
  * @return period in seconds as DBUS_TYPE_UINT32
  */
@@ -360,7 +360,7 @@
  * Note: The boolean reply message is optional and will be sent
  *       only if requested.
  *
- * @since v1.12.7
+ * @since v1.12.8
  *
  * @return success as DBUS_TYPE_BOOLEAN
  */
@@ -375,7 +375,7 @@
  * Note: The boolean reply message is optional and will be sent
  *       only if requested.
  *
- * @since v1.12.7
+ * @since v1.12.8
  *
  * @return success as DBUS_TYPE_BOOLEAN
  */
@@ -390,7 +390,7 @@
  * Note: The boolean reply message is optional and will be sent
  *       only if requested.
  *
- * @since v1.12.7
+ * @since v1.12.8
  *
  * @return success as DBUS_TYPE_BOOLEAN
  */


### PR DESCRIPTION
Applications can block suspend via:
 MCE_CPU_KEEPALIVE_PERIOD_REQ
 MCE_CPU_KEEPALIVE_START_REQ x N
 MCE_CPU_KEEPALIVE_STOP_REQ

And dsme can signal wakeup from suspend via:
 MCE_CPU_KEEPALIVE_WAKEUP_REQ
