### PR TITLE
Fix MCE_CPU_KEEPALIVE_PERIOD_REQ method call documentation

### DIFF
--- a/include/mce/dbus-names.h
+++ b/include/mce/dbus-names.h
@@ -346,7 +346,7 @@
  *
  * @since v1.12.8
  *
- * @return period in seconds as DBUS_TYPE_UINT32
+ * @return period in seconds as DBUS_TYPE_INT32
  */
 #define MCE_CPU_KEEPALIVE_PERIOD_REQ	"req_cpu_keepalive_period"
 


### PR DESCRIPTION
The value returned is dbus_int32_t, not dbus_uint32_t. Documentation
changed to match implementation.

[mce-headers] Fix MCE_CPU_KEEPALIVE_PERIOD_REQ method call documentation
