### PR TITLE
Add D-Bus constants for exposing display blanking policy

### DIFF
--- a/include/mce/dbus-names.h
+++ b/include/mce/dbus-names.h
@@ -306,6 +306,15 @@
  */
 #define MCE_BLANKING_INHIBIT_GET	"get_display_blanking_inhibit"
 
+/** Get current display blanking policy status
+ *
+ * @since v1.55.0
+ *
+ * @return @c gchar @c * with the blanking polic state
+ *         (see @ref mce/mode-names.h for valid blanking policy states)
+ */
+#define MCE_BLANKING_POLICY_GET         "get_display_blanking_policy"
+
 /**
  * Request CABC mode change
  *
@@ -521,6 +530,15 @@
  *         (see @ref mce/mode-names.h for valid blanking inhibit states)
  */
 #define MCE_BLANKING_INHIBIT_SIG	"display_blanking_inhibit_ind"
+
+/** Notify everyone when the display blanking policy changes
+ *
+ * @since v1.55.0
+ *
+ * @return @c gchar @c * with the display blankiing policy state
+ *         (see @ref mce/mode-names.h for valid blanking policy states)
+ */
+#define MCE_BLANKING_POLICY_SIG "display_blanking_policy_ind"
 
 /**
  * Notify everyone that the state of the automatic power saving mode changed

--- a/include/mce/mode-names.h
+++ b/include/mce/mode-names.h
@@ -185,6 +185,36 @@
  */
 #define MCE_INHIBIT_BLANK_INACTIVE_STRING	"inactive"
 
+/** Default blanking policy active
+ *
+ * @since v1.55.0
+ */
+#define MCE_BLANKING_POLICY_DEFAULT_STRING      "default"
+
+/** Default blanking policy disabled due to notifications
+ *
+ * @since v1.55.0
+ */
+#define MCE_BLANKING_POLICY_NOTIFICATION_STRING "notification"
+
+/** Default blanking policy disabled due to alarm dialog state
+ *
+ * @since v1.55.0
+ */
+#define MCE_BLANKING_POLICY_ALARM_STRING        "alarm"
+
+/** Default blanking policy disabled due to call state
+ *
+ * @since v1.55.0
+ */
+#define MCE_BLANKING_POLICY_CALL_STRING         "call"
+
+/** Default blanking policy is about to be restored
+ *
+ * @since v1.55.0
+ */
+#define MCE_BLANKING_POLICY_LINGER_STRING       "linger"
+
 /**
  * CABC name for CABC disabled
  *


### PR DESCRIPTION
New method call:
* get_display_blanking_policy

New signal:
* display_blanking_policy_ind