### PR TITLE
Add constants for powerkey events

### DIFF
--- a/include/mce/dbus-names.h
+++ b/include/mce/dbus-names.h
@@ -345,10 +345,8 @@
  *                trigger; @c FALSE == short powerkey press,
  *                         @c TRUE == long powerkey press
  * @since v1.10.54
- * @param type @c dbus_uint32_t with the type of powerkey event to
- *                trigger; @c 0 == short powerkey press,
- *                         @c 1 == long powerkey press,
- *                         @c 2 == double powerkey press
+ * @param type @c dbus_uint32_t with the type of powerkey event to trigger
+ *             (see @ref mce/mode-names.h for valid events)
  */
 #define MCE_TRIGGER_POWERKEY_EVENT_REQ	"req_trigger_powerkey_event"
 

--- a/include/mce/mode-names.h
+++ b/include/mce/mode-names.h
@@ -239,5 +239,23 @@
  * @since v1.8.88
  */
 #define MCE_CABC_MODE_MOVING_IMAGE		"moving-image"
+/**
+ * POWERKEY EVENT for single powerkey press
+ *
+ * @since v1.10.54
+ */
+#define MCE_POWERKEY_EVENT_SHORT_PRESS        (0u)
+/**
+ * POWERKEY EVENT for long powerkey press
+ *
+ * @since v1.10.54
+ */
+#define MCE_POWERKEY_EVENT_LONG_PRESS         (1u)
+/**
+ * POWERKEY EVENT for double powerkey press
+ *
+ * @since v1.10.54
+ */
+#define MCE_POWERKEY_EVENT_DOUBLE_PRESS       (2u)
 
 #endif /* _MCE_MODE_NAMES_H_ */


### PR DESCRIPTION
New constants
- MCE_POWERKEY_EVENT_SHORT_PRESS
- MCE_POWERKEY_EVENT_LONG_PRESS
- MCE_POWERKEY_EVENT_DOUBLE_PRESS

Fixes MER#1310
